### PR TITLE
Add careers page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -118,12 +118,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -734,11 +731,11 @@
       }
     },
     "node_modules/@mui/material-nextjs": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/@mui/material-nextjs/-/material-nextjs-6.1.3.tgz",
-      "integrity": "sha512-K+ZjCJ/3jhJWtWs1Sj1qovSbrlB+BekNdjnmbr7o0fQFF2x7NiW0J8SQpsk+pjwMrEQysCkVpQQy6HlqUXnTOw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@mui/material-nextjs/-/material-nextjs-6.5.0.tgz",
+      "integrity": "sha512-VV+4BhmnY32pbPuIevs+rPl0R+bkVvqGCqRqZqNhkdBdX0pn1IHQ5mG/EfYJKoKUkF7q9FKSag5wduSTUxDqnQ==",
       "dependencies": {
-        "@babel/runtime": "^7.25.6"
+        "@babel/runtime": "^7.26.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -752,7 +749,7 @@
         "@emotion/react": "^11.11.4",
         "@emotion/server": "^11.11.0",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "next": "^13.0.0 || ^14.0.0",
+        "next": "^13.0.0 || ^14.0.0 || ^15.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
@@ -908,9 +905,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.15.tgz",
-      "integrity": "sha512-S1qaj25Wru2dUpcIZMjxeMVSwkt8BK4dmWHHiBuRstcIyOsMapqT4A4jSB6onvqeygkSSmOkyny9VVx8JIGamQ=="
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.35.tgz",
+      "integrity": "sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ=="
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "14.1.0",
@@ -922,9 +919,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.15.tgz",
-      "integrity": "sha512-Rvh7KU9hOUBnZ9TJ28n2Oa7dD9cvDBKua9IKx7cfQQ0GoYUwg9ig31O2oMwH3wm+pE3IkAQ67ZobPfEgurPZIA==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.33.tgz",
+      "integrity": "sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==",
       "cpu": [
         "arm64"
       ],
@@ -937,9 +934,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.15.tgz",
-      "integrity": "sha512-5TGyjFcf8ampZP3e+FyCax5zFVHi+Oe7sZyaKOngsqyaNEpOgkKB3sqmymkZfowy3ufGA/tUgDPPxpQx931lHg==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.33.tgz",
+      "integrity": "sha512-8HGBeAE5rX3jzKvF593XTTFg3gxeU4f+UWnswa6JPhzaR6+zblO5+fjltJWIZc4aUalqTclvN2QtTC37LxvZAA==",
       "cpu": [
         "x64"
       ],
@@ -952,9 +949,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.15.tgz",
-      "integrity": "sha512-3Bwv4oc08ONiQ3FiOLKT72Q+ndEMyLNsc/D3qnLMbtUYTQAmkx9E/JRu0DBpHxNddBmNT5hxz1mYBphJ3mfrrw==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.33.tgz",
+      "integrity": "sha512-JXMBka6lNNmqbkvcTtaX8Gu5by9547bukHQvPoLe9VRBx1gHwzf5tdt4AaezW85HAB3pikcvyqBToRTDA4DeLw==",
       "cpu": [
         "arm64"
       ],
@@ -967,9 +964,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.15.tgz",
-      "integrity": "sha512-k5xf/tg1FBv/M4CMd8S+JL3uV9BnnRmoe7F+GWC3DxkTCD9aewFRH1s5rJ1zkzDa+Do4zyN8qD0N8c84Hu96FQ==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.33.tgz",
+      "integrity": "sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==",
       "cpu": [
         "arm64"
       ],
@@ -982,9 +979,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.15.tgz",
-      "integrity": "sha512-kE6q38hbrRbKEkkVn62reLXhThLRh6/TvgSP56GkFNhU22TbIrQDEMrO7j0IcQHcew2wfykq8lZyHFabz0oBrA==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.33.tgz",
+      "integrity": "sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==",
       "cpu": [
         "x64"
       ],
@@ -997,9 +994,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.15.tgz",
-      "integrity": "sha512-PZ5YE9ouy/IdO7QVJeIcyLn/Rc4ml9M2G4y3kCM9MNf1YKvFY4heg3pVa/jQbMro+tP6yc4G2o9LjAz1zxD7tQ==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.33.tgz",
+      "integrity": "sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==",
       "cpu": [
         "x64"
       ],
@@ -1012,9 +1009,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.15.tgz",
-      "integrity": "sha512-2raR16703kBvYEQD9HNLyb0/394yfqzmIeyp2nDzcPV4yPjqNUG3ohX6jX00WryXz6s1FXpVhsCo3i+g4RUX+g==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==",
       "cpu": [
         "arm64"
       ],
@@ -1027,9 +1024,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.15.tgz",
-      "integrity": "sha512-fyTE8cklgkyR1p03kJa5zXEaZ9El+kDNM5A+66+8evQS5e/6v0Gk28LqA0Jet8gKSOyP+OTm/tJHzMlGdQerdQ==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.33.tgz",
+      "integrity": "sha512-pc9LpGNKhJ0dXQhZ5QMmYxtARwwmWLpeocFmVG5Z0DzWq5Uf0izcI8tLc+qOpqxO1PWqZ5A7J1blrUIKrIFc7Q==",
       "cpu": [
         "ia32"
       ],
@@ -1042,9 +1039,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.15.tgz",
-      "integrity": "sha512-SzqGbsLsP9OwKNUG9nekShTwhj6JSB9ZLMWQ8g1gG6hdE5gQLncbnbymrwy2yVmH9nikSLYRYxYMFu78Ggp7/g==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==",
       "cpu": [
         "x64"
       ],
@@ -1054,6 +1051,17 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1104,6 +1112,14 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
       "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw=="
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -1325,9 +1341,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -1421,9 +1437,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -1693,9 +1709,9 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -1880,9 +1896,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -2184,13 +2200,13 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
     },
     "node_modules/editorconfig": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.4.tgz",
-      "integrity": "sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.7.tgz",
+      "integrity": "sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==",
       "dependencies": {
         "@one-ini/wasm": "0.1.1",
         "commander": "^10.0.0",
-        "minimatch": "9.0.1",
+        "minimatch": "^9.0.1",
         "semver": "^7.5.3"
       },
       "bin": {
@@ -2201,19 +2217,19 @@
       }
     },
     "node_modules/editorconfig/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/editorconfig/node_modules/minimatch": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
-      "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -3073,9 +3089,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true
     },
     "node_modules/for-each": {
@@ -3103,13 +3119,16 @@
       }
     },
     "node_modules/formidable": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.2.tgz",
-      "integrity": "sha512-Jqc1btCy3QzRbJaICGwKcBfGWuLADRerLzDqi2NwSt/UkXLsHJw2TVResiaoBufHVHy9aSgClOHCeJsSsFLTbg==",
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
       "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
         "dezalgo": "^1.0.4",
-        "hexoid": "^2.0.0",
         "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       },
       "funding": {
         "url": "https://ko-fi.com/tunnckoCore/commissions"
@@ -3238,19 +3257,19 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -3403,14 +3422,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/hexoid": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-2.0.0.tgz",
-      "integrity": "sha512-qlspKUK7IlSQv2o+5I7yhUd7TxlOG2Vr5LTa3ve2XSNVKAL/n/u/7KLvKmFNimomDIKvZFXWHv0T12mv7rT8Aw==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/hoist-non-react-statics": {
@@ -4006,9 +4017,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
@@ -4196,9 +4207,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -4268,9 +4279,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -4291,11 +4302,11 @@
       "dev": true
     },
     "node_modules/next": {
-      "version": "14.2.15",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.15.tgz",
-      "integrity": "sha512-h9ctmOokpoDphRvMGnwOJAedT6zKhwqyZML9mDtspgf4Rh3Pn7UTYKqePNoDvhsWBAO5GoPNYshnAUGIazVGmw==",
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.35.tgz",
+      "integrity": "sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==",
       "dependencies": {
-        "@next/env": "14.2.15",
+        "@next/env": "14.2.35",
         "@swc/helpers": "0.5.5",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",
@@ -4310,15 +4321,15 @@
         "node": ">=18.17.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "14.2.15",
-        "@next/swc-darwin-x64": "14.2.15",
-        "@next/swc-linux-arm64-gnu": "14.2.15",
-        "@next/swc-linux-arm64-musl": "14.2.15",
-        "@next/swc-linux-x64-gnu": "14.2.15",
-        "@next/swc-linux-x64-musl": "14.2.15",
-        "@next/swc-win32-arm64-msvc": "14.2.15",
-        "@next/swc-win32-ia32-msvc": "14.2.15",
-        "@next/swc-win32-x64-msvc": "14.2.15"
+        "@next/swc-darwin-arm64": "14.2.33",
+        "@next/swc-darwin-x64": "14.2.33",
+        "@next/swc-linux-arm64-gnu": "14.2.33",
+        "@next/swc-linux-arm64-musl": "14.2.33",
+        "@next/swc-linux-x64-gnu": "14.2.33",
+        "@next/swc-linux-x64-musl": "14.2.33",
+        "@next/swc-win32-arm64-msvc": "14.2.33",
+        "@next/swc-win32-ia32-msvc": "14.2.33",
+        "@next/swc-win32-x64-msvc": "14.2.33"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -4642,9 +4653,9 @@
       "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw=="
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "engines": {
         "node": ">=8.6"
@@ -4844,11 +4855,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.3",
@@ -5903,9 +5909,9 @@
       "integrity": "sha512-ncrLw+X55z7bkl5PnUvHwFK9FcGuFYo9gtjws2XtSzL+aZ8tm830P60WJ0dSmFVaSalWieW5MD7kEdnXda9yJw=="
     },
     "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "engines": {
         "node": ">= 6"
       }

--- a/src/components/CareersApplicationForm.tsx
+++ b/src/components/CareersApplicationForm.tsx
@@ -1,0 +1,329 @@
+"use client";
+import {
+   Alert,
+   AlertTitle,
+   Backdrop,
+   Box,
+   Button,
+   CircularProgress,
+   MenuItem,
+   Paper,
+   TextField,
+   Typography,
+   Zoom,
+} from "@mui/material";
+import React, { useState } from "react";
+import SendIcon from "@mui/icons-material/Send";
+import { MuiTelInput } from "mui-tel-input";
+import CloudUploadIcon from "@mui/icons-material/CloudUpload";
+
+const availablePositions = [
+   "Apprentice Plumber",
+   "Journeyman Plumber",
+   "Master Plumber",
+   "Service Plumber",
+   "New Construction Plumber",
+   "Drain Technician",
+   "Sewer/Water Line Installer",
+   "Plumbing Foreman",
+];
+
+const usStates = [
+   "Alabama",
+   "Alaska",
+   "Arizona",
+   "Arkansas",
+   "California",
+   "Colorado",
+   "Connecticut",
+   "Delaware",
+   "Florida",
+   "Georgia",
+   "Hawaii",
+   "Idaho",
+   "Illinois",
+   "Indiana",
+   "Iowa",
+   "Kansas",
+   "Kentucky",
+   "Louisiana",
+   "Maine",
+   "Maryland",
+   "Massachusetts",
+   "Michigan",
+   "Minnesota",
+   "Mississippi",
+   "Missouri",
+   "Montana",
+   "Nebraska",
+   "Nevada",
+   "New Hampshire",
+   "New Jersey",
+   "New Mexico",
+   "New York",
+   "North Carolina",
+   "North Dakota",
+   "Ohio",
+   "Oklahoma",
+   "Oregon",
+   "Pennsylvania",
+   "Rhode Island",
+   "South Carolina",
+   "South Dakota",
+   "Tennessee",
+   "Texas",
+   "Utah",
+   "Vermont",
+   "Virginia",
+   "Washington",
+   "West Virginia",
+   "Wisconsin",
+   "Wyoming",
+];
+
+const supportedResumeTypes = [
+   "application/pdf",
+   "application/msword",
+   "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+];
+
+const maxResumeSizeInMB = 5;
+
+const CareersApplicationForm: React.FC = () => {
+   const [loading, setLoading] = useState(false);
+   const [messageSent, setMessageSent] = useState(false);
+   const [error, setError] = useState("");
+   const [phoneValue, setPhoneValue] = useState("");
+   const [resume, setResume] = useState<File | null>(null);
+
+   const checkValidity = () => {
+      if (!phoneValue || phoneValue.replace(/\s+/g, "").length < 12) {
+         setError("Phone number is required.");
+         return false;
+      }
+      if (!resume) {
+         setError("Resume is required.");
+         return false;
+      }
+      return true;
+   };
+
+   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      setLoading(true);
+      setError("");
+
+      if (!checkValidity()) {
+         setLoading(false);
+         return;
+      }
+
+      const formData = new FormData(event.currentTarget);
+      if (resume) formData.append("resume", resume);
+
+      const res = await fetch("/api/send-application", {
+         method: "POST",
+         body: formData,
+      });
+
+      if (res.ok) {
+         setMessageSent(true);
+      } else {
+         setError(
+            "There was an error sending your application. Please try again later."
+         );
+      }
+
+      setLoading(false);
+   };
+
+   const handleResumeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      if (!e.target.files?.length) return;
+      setError("");
+
+      const file = e.target.files[0];
+      if (!supportedResumeTypes.includes(file.type)) {
+         setError("Resume must be a PDF or Word document.");
+         e.target.value = "";
+         return;
+      }
+
+      if (file.size > maxResumeSizeInMB * 1024 * 1024) {
+         setError(`Resume must be ${maxResumeSizeInMB}MB or smaller.`);
+         e.target.value = "";
+         return;
+      }
+
+      setResume(file);
+   };
+
+   return (
+      <Paper
+         component={"form"}
+         onSubmit={handleSubmit}
+         variant="outlined"
+         sx={{
+            p: "1rem",
+            mt: "0.5rem",
+            backgroundColor: "secondary.main",
+            borderRadius: "0.5rem",
+            position: "relative",
+         }}
+      >
+         <Box>
+            {!!error && (
+               <Alert severity="error">
+                  <AlertTitle>Error</AlertTitle>
+                  {error}
+               </Alert>
+            )}
+            <TextField
+               required
+               select
+               name="position"
+               label="Position Applying For"
+               fullWidth
+               margin="normal"
+               defaultValue=""
+            >
+               <MenuItem value="" disabled>
+                  Select a position
+               </MenuItem>
+               {availablePositions.map((position) => (
+                  <MenuItem key={position} value={position}>
+                     {position}
+                  </MenuItem>
+               ))}
+            </TextField>
+            <TextField
+               required
+               name="name"
+               label="Full Name"
+               fullWidth
+               margin="normal"
+            />
+            <TextField
+               required
+               name="email"
+               type="email"
+               label="Email"
+               fullWidth
+               margin="normal"
+            />
+            <MuiTelInput
+               required
+               label="Phone Number"
+               forceCallingCode
+               defaultCountry="US"
+               onlyCountries={["US", "CA"]}
+               sx={{ width: "100%" }}
+               name="phone"
+               value={phoneValue}
+               onChange={setPhoneValue}
+               margin="normal"
+               error={error.toLowerCase().includes("phone")}
+            />
+            <TextField
+               required
+               name="currentCity"
+               label="Current City"
+               fullWidth
+               margin="normal"
+            />
+            <TextField
+               required
+               select
+               name="currentState"
+               label="Current State"
+               fullWidth
+               margin="normal"
+               defaultValue=""
+            >
+               <MenuItem value="" disabled>
+                  Select a state
+               </MenuItem>
+               {usStates.map((state) => (
+                  <MenuItem key={state} value={state}>
+                     {state}
+                  </MenuItem>
+               ))}
+            </TextField>
+            <TextField
+               required
+               name="yearsExperience"
+               type="number"
+               label="Years of Experience"
+               fullWidth
+               margin="normal"
+               slotProps={{ htmlInput: { min: 0, max: 60 } }}
+            />
+            <input
+               id="resume-input"
+               type="file"
+               accept=".pdf,.doc,.docx"
+               onChange={handleResumeChange}
+               style={{ display: "none" }}
+            />
+            <label htmlFor="resume-input">
+               <Button
+                  component="span"
+                  variant="outlined"
+                  sx={{ mt: "0.5rem" }}
+                  endIcon={<CloudUploadIcon />}
+               >
+                  Upload Resume
+               </Button>
+            </label>
+            {!!resume && (
+               <Typography sx={{ mt: "0.5rem", fontSize: "0.95rem" }}>
+                  Attached: {resume.name}
+               </Typography>
+            )}
+            <Box sx={{ display: "flex", justifyContent: "flex-end", mt: 1 }}>
+               <Button
+                  variant="contained"
+                  type="submit"
+                  disabled={loading}
+                  endIcon={<SendIcon />}
+               >
+                  Submit Application
+               </Button>
+            </Box>
+         </Box>
+
+         <Backdrop
+            open={loading || messageSent}
+            sx={{
+               position: "absolute",
+               borderRadius: "0.5rem",
+               backgroundColor: "primary.dark",
+            }}
+         >
+            {messageSent ? (
+               <Box>
+                  <Zoom in={messageSent}>
+                     <Box sx={{ textAlign: "center", position: "relative", zIndex: 1 }}>
+                        <Typography
+                           sx={{
+                              color: "white",
+                              fontWeight: "bold",
+                              fontSize: "1.5rem",
+                           }}
+                        >
+                           Application submitted!
+                        </Typography>
+                        <Typography sx={{ color: "white" }}>
+                           Thanks for applying. We will review and reach out soon.
+                        </Typography>
+                     </Box>
+                  </Zoom>
+               </Box>
+            ) : (
+               <CircularProgress sx={{ color: "primary.light" }} />
+            )}
+         </Backdrop>
+      </Paper>
+   );
+};
+
+export default CareersApplicationForm;

--- a/src/components/CareersApplicationForm.tsx
+++ b/src/components/CareersApplicationForm.tsx
@@ -18,14 +18,8 @@ import { MuiTelInput } from "mui-tel-input";
 import CloudUploadIcon from "@mui/icons-material/CloudUpload";
 
 const availablePositions = [
-   "Apprentice Plumber",
    "Journeyman Plumber",
-   "Master Plumber",
-   "Service Plumber",
-   "New Construction Plumber",
-   "Drain Technician",
-   "Sewer/Water Line Installer",
-   "Plumbing Foreman",
+   "Customer Service Representative"
 ];
 
 const usStates = [

--- a/src/components/email/careers-email-template.tsx
+++ b/src/components/email/careers-email-template.tsx
@@ -1,20 +1,27 @@
 import theme from "@/app/theme";
 import { siteURL } from "@/content";
 import * as React from "react";
-export interface EmailTemplateProps {
+
+export interface CareersEmailTemplateProps {
    name: string;
-   phoneNumber?: string;
+   phoneNumber: string;
    email: string;
-   message: string;
-   subject?: string;
+   position: string;
+   currentCity: string;
+   currentState: string;
+   yearsExperience: string;
 }
 
-export const EmailTemplate: React.FC<Readonly<EmailTemplateProps>> = ({
+export const CareersEmailTemplate: React.FC<
+   Readonly<CareersEmailTemplateProps>
+> = ({
    name,
    phoneNumber,
    email,
-   message,
-   subject,
+   position,
+   currentCity,
+   currentState,
+   yearsExperience,
 }) => {
    const logoUrl = `https://${siteURL}/assets/dog_logo_no_background.png`;
 
@@ -61,19 +68,15 @@ export const EmailTemplate: React.FC<Readonly<EmailTemplateProps>> = ({
                      color: theme.palette.primary.main,
                   }}
                >
-                  New Website Message
+                  New Careers Application
                </h1>
             </div>
 
             <div style={{ padding: "1.25rem" }}>
                <p style={{ margin: "0 0 0.75rem 0", fontSize: "1rem" }}>
-                  From: <strong>{name}</strong>
+                  Applicant: <strong>{name}</strong>
                </p>
-               {!!subject && (
-                  <p style={{ margin: "0 0 1rem 0", fontSize: "1rem" }}>
-                     Subject: <strong>{subject}</strong>
-                  </p>
-               )}
+
                <div
                   style={{
                      marginBottom: "1rem",
@@ -83,17 +86,11 @@ export const EmailTemplate: React.FC<Readonly<EmailTemplateProps>> = ({
                      backgroundColor: "#fafcff",
                   }}
                >
-                  <p
-                     style={{
-                        margin: "0 0 0.4rem 0",
-                        fontWeight: 700,
-                        fontSize: "0.95rem",
-                     }}
-                  >
-                     Message
+                  <p style={{ margin: "0 0 0.35rem 0" }}>
+                     Position: <strong>{position}</strong>
                   </p>
-                  <p style={{ margin: "0", whiteSpace: "pre-wrap", wordBreak: "break-word" }}>
-                     {message}
+                  <p style={{ margin: "0" }}>
+                     Years of Experience: <strong>{yearsExperience}</strong>
                   </p>
                </div>
 
@@ -110,14 +107,13 @@ export const EmailTemplate: React.FC<Readonly<EmailTemplateProps>> = ({
                   <p style={{ margin: "0 0 0.35rem 0" }}>
                      Email: <a href={`mailto:${email}`}>{email}</a>
                   </p>
-                  {!!phoneNumber && (
-                     <p style={{ margin: "0" }}>
-                        Phone:{" "}
-                        <a href={`tel:${phoneNumber.replace(/\D+/g, "")}`}>
-                           {phoneNumber}
-                        </a>
-                     </p>
-                  )}
+                  <p style={{ margin: "0 0 0.35rem 0" }}>
+                     Phone:{" "}
+                     <a href={`tel:${phoneNumber.replace(/\D+/g, "")}`}>{phoneNumber}</a>
+                  </p>
+                  <p style={{ margin: "0" }}>
+                     Current Location: <strong>{currentCity}, {currentState}</strong>
+                  </p>
                </div>
             </div>
          </div>

--- a/src/components/home/JoinTeamCallout.tsx
+++ b/src/components/home/JoinTeamCallout.tsx
@@ -1,0 +1,38 @@
+import {
+   Box,
+} from "@mui/material";
+import Link from "next/link";
+import React from "react";
+
+
+export function JoinTeamRibbon() {
+   return (
+      <Box
+         component={Link}
+         href="/careers"
+         sx={{
+            position: "absolute",
+            top: {xs: "0rem", md: "0.5rem" },
+            left: "-2.75rem",
+            zIndex: 3,
+            bgcolor: "error.main",
+            color: "error.contrastText",
+            px: { xs: 2.5, md: 3.5 },
+            py: { xs: 1, md: 1.25 },
+            transform: "rotate(-11deg)",
+            transformOrigin: "0 0",
+            boxShadow: 3,
+            fontSize: { xs: "0.8rem", md: "0.95rem" },
+            fontWeight: 800,
+            letterSpacing: 0.06,
+            textAlign: "center",
+            maxWidth: { xs: 220, md: 300 },
+            lineHeight: 1.35,
+            textDecoration: "none",
+            borderRadius: 2
+         }}
+      >
+         Now Hiring · Join Our Team
+      </Box>
+   );
+}

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -20,6 +20,7 @@ export const pages: ReadonlyArray<{
 }> = [
    { title: "Home", url: "/" },
    { title: "Contact", url: "/contact" },
+   { title: "Careers", url: "/careers" },
    { title: "Reviews", url: "/reviews" },
    { title: "Our Team", url: "/team" }
 ];

--- a/src/lib/email/destination-emails.ts
+++ b/src/lib/email/destination-emails.ts
@@ -1,0 +1,25 @@
+import { ContactInfo } from "@/content";
+
+interface DestinationEmailOptions {
+   subject?: string;
+}
+
+export const getDestinationEmails = (
+   options?: DestinationEmailOptions
+): string[] => {
+   const vercelEnv = (process.env.VERCEL_ENV ?? "").toLowerCase();
+   const nodeEnv = (process.env.NODE_ENV ?? "").toLowerCase();
+   const testerEmail = "glen.a.simon@gmail.com";
+   const isLocal = !vercelEnv && (!nodeEnv || nodeEnv === "development");
+   const hasTesterKeyword = options?.subject?.toUpperCase().includes("TEST-EMAIL");
+
+   if (isLocal) {
+      return [testerEmail];
+   }
+
+   if (hasTesterKeyword) {
+      return [testerEmail];
+   }
+
+   return [ContactInfo.email.text];
+};

--- a/src/lib/email/form-data.ts
+++ b/src/lib/email/form-data.ts
@@ -1,0 +1,60 @@
+import formidable, { File as FormidableFile } from "formidable";
+import fs from "fs";
+import type { NextApiRequest } from "next";
+
+export interface ParsedFormData {
+   fields: Record<string, string>;
+   files: Record<string, FormidableFile[]>;
+}
+
+export interface UploadedAttachment {
+   content: Buffer;
+   filename: string;
+   type: string;
+   filepath: string;
+}
+
+const toArray = <T>(value: T | T[] | undefined): T[] => {
+   if (!value) return [];
+   return Array.isArray(value) ? value : [value];
+};
+
+export const parseMultipartForm = async (
+   req: NextApiRequest
+): Promise<ParsedFormData> => {
+   const form = formidable({ allowEmptyFiles: false, minFileSize: 1 });
+   const [rawFields, rawFiles] = await form.parse(req);
+
+   const fields = Object.fromEntries(
+      Object.entries(rawFields).map(([key, value]) => [key, value?.[0] ?? ""])
+   );
+
+   const files = Object.fromEntries(
+      Object.entries(rawFiles).map(([key, value]) => [key, toArray(value)])
+   );
+
+   return { fields, files };
+};
+
+export const getAttachmentsFromFiles = (
+   files: FormidableFile[] | undefined
+): UploadedAttachment[] => {
+   return toArray(files)
+      .filter((file) => file.size > 0)
+      .map((file) => ({
+         content: fs.readFileSync(file.filepath),
+         filename: file.originalFilename ?? "attachment",
+         type: file.mimetype ?? "application/octet-stream",
+         filepath: file.filepath,
+      }));
+};
+
+export const cleanupUploadedFiles = (
+   attachments: Pick<UploadedAttachment, "filepath">[]
+) => {
+   for (const file of attachments) {
+      if (fs.existsSync(file.filepath)) {
+         fs.unlinkSync(file.filepath);
+      }
+   }
+};

--- a/src/pages/api/send-application.ts
+++ b/src/pages/api/send-application.ts
@@ -1,0 +1,83 @@
+import { CareersEmailTemplate } from "@/components/email/careers-email-template";
+import { siteTitle, siteURL } from "@/content";
+import { getDestinationEmails } from "@/lib/email/destination-emails";
+import {
+   cleanupUploadedFiles,
+   getAttachmentsFromFiles,
+   ParsedFormData,
+   parseMultipartForm,
+} from "@/lib/email/form-data";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { Resend } from "resend";
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+
+const sendApplication = async (req: NextApiRequest, res: NextApiResponse) => {
+   let parsed: ParsedFormData;
+   try {
+      parsed = await parseMultipartForm(req);
+   } catch (e) {
+      console.error(e);
+      return res.status(500).json({ error: "Error parsing form data" });
+   }
+
+   const { fields, files } = parsed;
+   const attachments = getAttachmentsFromFiles(files.resume).slice(0, 1);
+
+   if (
+      !fields.name ||
+      !fields.email ||
+      !fields.phone ||
+      !fields.currentCity ||
+      !fields.currentState ||
+      !fields.position ||
+      !fields.yearsExperience ||
+      attachments.length === 0
+   ) {
+      cleanupUploadedFiles(attachments);
+      return res.status(400).json({ error: "Missing required fields" });
+   }
+
+   try {
+      const subject = `Website Job Application - ${fields.position}`;
+      const { data, error } = await resend.emails.send({
+         from: `${siteTitle}<${siteURL}@glenasimon.com>`,
+         to: getDestinationEmails({ subject }),
+         subject,
+         react: CareersEmailTemplate({
+            name: fields.name,
+            email: fields.email,
+            phoneNumber: fields.phone,
+            position: fields.position,
+            currentCity: fields.currentCity,
+            currentState: fields.currentState,
+            yearsExperience: fields.yearsExperience,
+         }),
+         ...(attachments.length > 0 && {
+            attachments: attachments.map((file) => ({
+               content: file.content,
+               filename: file.filename,
+               type: file.type,
+            })),
+         }),
+      });
+
+      if (error) {
+         console.error(error);
+         // @ts-ignore - statusCode is not defined on the error object, but is passed along
+         return res.status(error?.statusCode ?? "500").json(error);
+      }
+
+      return res.status(200).json(data);
+   } finally {
+      cleanupUploadedFiles(attachments);
+   }
+};
+
+export default sendApplication;
+
+export const config = {
+   api: {
+      bodyParser: false,
+   },
+};

--- a/src/pages/api/send.ts
+++ b/src/pages/api/send.ts
@@ -1,84 +1,66 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { EmailTemplate } from "../../components/email/contact-email-template";
 import { Resend } from "resend";
-import { ContactInfo, siteTitle, siteURL } from "@/content";
-import formidable from "formidable";
-import fs from "fs";
+import { siteTitle, siteURL } from "@/content";
+import { getDestinationEmails } from "@/lib/email/destination-emails";
+import {
+   cleanupUploadedFiles,
+   getAttachmentsFromFiles,
+   ParsedFormData,
+   parseMultipartForm,
+} from "@/lib/email/form-data";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
 const sendEmail = async (req: NextApiRequest, res: NextApiResponse) => {
-   const form = formidable({ allowEmptyFiles: false, minFileSize: 1 });
-
-   let fields;
-   let files;
+   let parsed: ParsedFormData;
    try {
-      [fields, files] = await form.parse(req);
+      parsed = await parseMultipartForm(req);
    } catch (e) {
       console.error(e);
       return res.status(500).json({ error: "Error parsing form data" });
    }
 
-   // Transform fields into string values instead of string arrays
-   fields = Object.fromEntries(
-      Object.entries(fields).map(([key, value]) => [key, value ? value[0] : ""])
-   );
-
-   // Transform files into objects with content property
-   const images = Object.entries(files.images ?? [])
-      .filter(([key, file]) => file.size > 0)
-      .map(([key, value]) => ({
-         ...value,
-         content: fs.readFileSync(value.filepath),
-      }));
+   const { fields, files } = parsed;
+   const images = getAttachmentsFromFiles(files.images);
 
    if (!fields.name || !fields.phone || !fields.message) {
       return res.status(400).json({ error: "Missing required fields" });
    }
 
-   const getDestinationEmails = (): string[] => {
-      const env = process.env.VERCEL_ENV ?? process.env.NODE_ENV;
+   try {
+      const { data, error } = await resend.emails.send({
+         from: `${siteTitle}<${siteURL}@glenasimon.com>`,
+         to: getDestinationEmails({
+            subject: fields.subject
+         }),
+         subject: `Website Message - ${fields.subject}`,
+         react: EmailTemplate({
+            name: fields.name,
+            phoneNumber: fields.phone,
+            email: fields.email,
+            message: fields.message,
+            subject: fields.subject,
+         }),
+         ...(images.length > 0 && {
+            attachments: images.map((image) => ({
+               content: image.content,
+               filename: image.filename,
+               type: image.type,
+            })),
+         }),
+      });
 
-      if (env.toLowerCase() === "production") {
-         return [ContactInfo.email.text];
-      } else if (fields.subject?.toLowerCase().includes("brody")) {
-         return ["glen.a.simon@gmail.com", ContactInfo.email.text];
+      if (error) {
+         console.error(error);
+         // @ts-ignore - statusCode is not defined on the error object, but is passed along
+         return res.status(error?.statusCode ?? "500").json(error);
       }
-      return ["glen.a.simon@gmail.com"];
-   };
 
-   const { data, error } = await resend.emails.send({
-      from: `${siteTitle}<${siteURL}@glenasimon.com>`,
-      to: getDestinationEmails(),
-      subject: `Website Message - ${fields.subject}`,
-      react: EmailTemplate({
-         name: fields.name,
-         phoneNumber: fields.phone,
-         email: fields.email,
-         message: fields.message,
-         subject: fields.subject,
-      }),
-      ...(images.length > 0 && {
-         attachments: images.map((image) => ({
-            content: image.content,
-            filename: image.originalFilename ?? "image.png",
-            type: image.mimetype,
-         })),
-      }),
-   });
-
-   // Clean up temporary files
-   if (images.length > 0) {
-      for (let img of images) fs.unlinkSync(img.filepath);
+      return res.status(200).json(data);
+   } finally {
+      cleanupUploadedFiles(images);
    }
-
-   if (error) {
-      console.error(error);
-      // @ts-ignore - statusCode is not defined on the error object, but is passed along
-      return res.status(error?.statusCode ?? "500").json(error);
-   }
-
-   res.status(200).json(data);
 };
 
 export default sendEmail;

--- a/src/pages/careers.tsx
+++ b/src/pages/careers.tsx
@@ -24,7 +24,7 @@ const CareersPage = () => {
                      Want to work with us?
                   </Typography>
                   <Typography variant="h6" sx={{ mt: 1 }}>
-                     Submit a quick prescreen application and tell us what plumbing
+                     Submit a quick prescreen application and tell us what
                      position you are looking for.
                   </Typography>
                   <CareersApplicationForm />

--- a/src/pages/careers.tsx
+++ b/src/pages/careers.tsx
@@ -1,0 +1,38 @@
+import Content from "@/components/Content";
+import MainContentWrapper from "@/components/MainContentWrapper";
+import CareersApplicationForm from "@/components/CareersApplicationForm";
+import { siteTitle } from "@/content";
+import { Grid, Typography } from "@mui/material";
+import Head from "next/head";
+
+export const getStaticProps = async () => {
+   return {
+      props: {},
+   };
+};
+
+const CareersPage = () => {
+   return (
+      <>
+         <Head>
+            <title>{`Careers | ${siteTitle}`}</title>
+         </Head>
+         <MainContentWrapper>
+            <Grid item xs={12} sm={12} md={12} lg={12}>
+               <Content>
+                  <Typography variant="h4" sx={{ fontWeight: "bold" }}>
+                     Want to work with us?
+                  </Typography>
+                  <Typography variant="h6" sx={{ mt: 1 }}>
+                     Submit a quick prescreen application and tell us what plumbing
+                     position you are looking for.
+                  </Typography>
+                  <CareersApplicationForm />
+               </Content>
+            </Grid>
+         </MainContentWrapper>
+      </>
+   );
+};
+
+export default CareersPage;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,5 @@
 import Content from "@/components/Content";
+import { JoinTeamRibbon } from "@/components/home/JoinTeamCallout";
 import MainContentWrapper from "@/components/MainContentWrapper";
 import Service from "@/components/Service";
 import { ContactInfo, siteTitle, headerLogo } from "@/content";
@@ -23,7 +24,9 @@ const Page = () => {
          <MainContentWrapper>
             <Grid item xs={12} sm={12} md={12} lg={12}>
                <Content>
-                  <Grid container spacing={2}>
+                  <Box sx={{ position: "relative", overflow: "visible" }}>
+                     <JoinTeamRibbon />
+                     <Grid container spacing={2}>
                      <Grid item xs={12} sm={12} md={12} lg={5} xl={4}>
                         <Box
                            sx={{
@@ -111,10 +114,11 @@ const Page = () => {
                                  alt="Rinnai Pro"
                               />
                            </Link>
-                           <BBBSeal sx={{ justifyContent: "flex-end" }} />
+                           {/* <BBBSeal sx={{ justifyContent: "flex-end" }} /> */}
                         </Box>
                      </Grid>
                   </Grid>
+                  </Box>
                </Content>
             </Grid>
             <Grid item xs={12} sm={12} md={12} lg={12}>


### PR DESCRIPTION
## Summary

This merge request adds a new Careers prescreen application funnel and aligns it with the existing contact/email pipeline.

### What was added

- New full-width careers page at `/careers` with “Want to work with us?” funnel content.
- New `CareersApplicationForm` with required fields:
  - Position Applying For (moved to top of form)
  - Full Name
  - Email
  - Phone
  - Current City
  - Current State (50 U.S. states dropdown)
  - Years of Experience
  - Resume upload (required)
- Example plumbing trade position list added to the position dropdown.
- New API endpoint: `/api/send-application` for multipart submission handling and email delivery.
- New careers email template for application notifications.

### Refactor / shared logic

- Extracted shared multipart parsing and file attachment logic into reusable utility:
  - `src/lib/email/form-data.ts`
- Updated existing contact API route to use shared form-data/email attachment helpers.
- Kept contact-specific routing/subject behavior in the contact endpoint.

### Email template improvements

- Updated both contact and careers email templates with improved professional styling.
- Added company logo to both templates:
  - `/assets/dog_logo_no_background.png`
- Updated logo dimensions to `250x200` per latest requirement.

### Navigation

- Added `Careers` page link to site nav/page config.

## API/Behavior notes

- Careers submissions now require:
  - all prescreen fields (including state)
  - at least one resume attachment
- Resume upload supports common document formats and client-side validation.
- Contact endpoint remains functional with the shared utility refactor.

## Test Plan

- [x] Run lint: `npm run lint`
- [x] Verify `/careers` page renders full-width and form loads correctly.
- [x] Verify position dropdown renders expected plumber-trade roles.
- [x] Verify state dropdown includes all 50 U.S. states.
- [x] Verify resume is required (client + server validation).
- [x] Verify successful application submit sends email via `/api/send-application`.
- [x] Verify contact form still submits successfully through `/api/send` after refactor.
- [x] Verify updated email templates render logo and styled layout.

## Risk / Rollback

### Risk
- Low to moderate: touches form UX, API upload flow, and email template rendering.

### Rollback
- Revert the careers page/component/api/template files and restore previous `send.ts` implementation (or revert this MR commit set).