### PR TITLE
Keep footer at the bottom of short pages

### DIFF
--- a/src/components/SiteLayout.tsx
+++ b/src/components/SiteLayout.tsx
@@ -11,7 +11,7 @@ export default function SiteLayout({
    return (
       <Box className="site-shell">
          <NavigationHeader />
-         <Box style={{ flex: "1 0 auto" }}>
+         <Box className="site-main">
             <Container size={maxWidth} px={{ base: "sm", sm: "md", lg: "xl" }} py={{ base: "md", md: "xl" }}>
                {children}
             </Container>

--- a/src/globals.css
+++ b/src/globals.css
@@ -2,8 +2,12 @@ html,
 body,
 #__next {
    min-height: 100%;
+   min-height: 100vh;
+   min-height: 100dvh;
    width: 100%;
    max-width: 100%;
+   display: flex;
+   flex-direction: column;
 }
 
 html,
@@ -17,7 +21,10 @@ body {
 }
 
 .site-shell {
+   flex: 1 0 auto;
    min-height: 100%;
+   min-height: 100vh;
+   min-height: 100dvh;
    width: 100%;
    display: flex;
    flex-direction: column;
@@ -28,6 +35,10 @@ body {
    background-repeat: repeat;
    background-position: 0 0;
    background-size: auto;
+}
+
+.site-main {
+   flex: 1 0 auto;
 }
 
 .site-shell::before {
@@ -211,6 +222,7 @@ body {
    background: #0c1224;
    color: white;
    margin-top: 2.5rem;
+   flex-shrink: 0;
 }
 
 .services-carousel {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -24,7 +24,10 @@ export default function MyApp({ Component, pageProps }: AppProps) {
          <MantineProvider theme={theme} defaultColorScheme="light" forceColorScheme="light">
             <Notifications />
             <Analytics />
-            <div className={inter.className} style={{ minHeight: "100%" }}>
+            <div
+               className={inter.className}
+               style={{ minHeight: "100%", display: "flex", flexDirection: "column", flex: 1 }}
+            >
                <Layout>
                   <Component {...pageProps} />
                </Layout>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -4,14 +4,14 @@ import { Head, Html, Main, NextScript } from "next/document";
 
 export default function MyDocument() {
    return (
-      <Html lang="en" {...mantineHtmlProps} style={{ height: "100%" }}>
+      <Html lang="en" {...mantineHtmlProps}>
          <Head>
             <ColorSchemeScript defaultColorScheme="light" />
             <meta name="description" content={siteDescription} />
             <link rel="icon" href="/favicon.png?v=3" type="image/png" />
             <link rel="apple-touch-icon" href="/favicon.png?v=3" />
          </Head>
-         <body style={{ margin: 0, height: "100%" }}>
+         <body>
             <Main />
             <NextScript />
          </body>


### PR DESCRIPTION
## Summary
- Fill the viewport with a column flex layout so short pages still stretch to the window height.
- Let the main content grow and keep the footer at the bottom of the viewport.

## Test plan
- [x] Open Contact (and another short page) on a tall desktop window and confirm the footer sits at the bottom with no gap below it.
- [x] Open Home or another tall page and confirm the page still scrolls normally and the footer stays after the content.
- [x] Check a mobile viewport for the same footer behavior.


Made with [Cursor](https://cursor.com)